### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  nagios:
+    image: cpuchalver/nagios:latest
+    ports:
+      - "8080:80"
+      - "5667:5667"


### PR DESCRIPTION
This pull request adds a new Nagios monitoring service to the `docker-compose.yml` configuration.

Service addition:

* Added a `nagios` service using the `cpuchalver/nagios:latest` image, exposing ports 8080 and 5667 for web and monitoring access.